### PR TITLE
Implement workout UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
   <section id="workout-section" class="hidden">
     <h2>Exercises</h2>
+    <button id="home-button">Home</button>
     <div id="exercise-list"></div>
     <button id="save-workout">Save Workout</button>
     <button id="save-template">Save as Template</button>

--- a/style.css
+++ b/style.css
@@ -56,6 +56,12 @@ button {
     margin-right: 0.25rem;
 }
 
+.set-item .history {
+    margin-right: 0.25rem;
+    font-size: 0.9rem;
+    color: #666;
+}
+
 .history-entry {
     background: #fff;
     padding: 0.5rem;


### PR DESCRIPTION
## Summary
- add Home button to exit a workout
- display past set history per exercise
- store last sets in local storage when saving
- clear done ticks when starting from a template
- add style for history column

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68644f275e7883278f87f8f2db897c20