### PR TITLE
Add exercise selection from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ This offline-capable web application helps you build and repeat workouts directl
 - Reorder exercises and edit set details as you train
 - Tick off sets to automatically start a rest countdown
 - Save the workout and view previous sessions in the history list
+- Select exercises you've done before when adding a new one, with the same number of sets as last time
 
 All data is stored locally in the browser and a service worker keeps the page available offline. Open `index.html` in your mobile browser (optimised for iPhone) and start tracking your workouts.

--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
 
   <section id="add-exercise-section" class="hidden">
     <form id="add-exercise-form">
-      <input type="text" id="exercise-name" placeholder="New exercise" required>
+      <input type="text" id="exercise-name" list="exercise-options" placeholder="New exercise" required>
+      <datalist id="exercise-options"></datalist>
       <button type="submit">Add Exercise</button>
     </form>
   </section>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const exerciseList = document.getElementById('exercise-list');
 const addExerciseForm = document.getElementById('add-exercise-form');
 const exerciseNameInput = document.getElementById('exercise-name');
+const exerciseOptions = document.getElementById('exercise-options');
 const saveWorkoutBtn = document.getElementById('save-workout');
 const saveTemplateBtn = document.getElementById('save-template');
 const historyList = document.getElementById('history-list');
@@ -61,6 +62,16 @@ function renderTemplateList() {
     btn.textContent = t.name;
     btn.dataset.index = i;
     templateList.appendChild(btn);
+  });
+}
+
+function renderExerciseOptions() {
+  const hist = loadExerciseHistory();
+  exerciseOptions.innerHTML = '';
+  Object.keys(hist).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    exerciseOptions.appendChild(opt);
   });
 }
 
@@ -173,7 +184,11 @@ addExerciseForm.addEventListener('submit', e => {
   e.preventDefault();
   const name = exerciseNameInput.value.trim();
   if (!name) return;
-  workout.exercises.push({ name, sets: [{ weight: '', reps: '', done: false }] });
+  const lastSets = getLastExerciseSets(name);
+  const sets = lastSets
+    ? lastSets.map(() => ({ weight: '', reps: '', done: false }))
+    : [{ weight: '', reps: '', done: false }];
+  workout.exercises.push({ name, sets });
   exerciseNameInput.value = '';
   saveWorkout();
   renderWorkout();
@@ -248,6 +263,7 @@ saveWorkoutBtn.addEventListener('click', () => {
     exHist[ex.name] = JSON.parse(JSON.stringify(ex.sets));
   });
   saveExerciseHistory(exHist);
+  renderExerciseOptions();
   saveWorkout();
   renderHistory();
 });
@@ -302,6 +318,7 @@ templateList.addEventListener('click', e => {
 function init() {
   loadWorkout();
   renderTemplateList();
+  renderExerciseOptions();
   showWorkoutUI(false);
   startSection.classList.remove('hidden');
   renderWorkout();


### PR DESCRIPTION
## Summary
- allow selecting previous exercises via a datalist
- when adding an exercise use the same number of sets as last time
- track previous exercise names in a datalist on save
- document the new functionality

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864547dd39c832784aa1759b4329e45