### PR TITLE
Add exercise history view and logout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <h2>Select Workout</h2>
     <button id="start-blank">Start Blank Workout</button>
     <div id="template-list"></div>
+    <button id="logout-button" class="hidden">Logout</button>
   </section>
 
   <section id="rest-section" class="hidden">

--- a/style.css
+++ b/style.css
@@ -105,3 +105,14 @@ ul {
     width: 100%;
     background: #4caf50;
 }
+
+.prev-attempts {
+    background: #eef;
+    padding: 0.25rem;
+    margin-top: 0.25rem;
+    font-size: 0.9rem;
+}
+
+#logout-button {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add logout button on home screen
- allow clicking an exercise title to view previous attempts
- hide nav controls after logout
- tidy timestamp display in history
- style attempts popup and logout button

## Testing
- `node --check script.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f78dbaf083278c663053884dc5f1