### PR TITLE
Enhance rest timer UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,6 +60,7 @@ button {
     display: flex;
     align-items: center;
     margin-bottom: 0.25rem;
+    flex-wrap: wrap;
 }
 
 .set-item input[type="number"] {
@@ -98,12 +99,24 @@ ul {
     background: #ddd;
     margin-top: 0.25rem;
     position: relative;
+    flex-basis: 100%;
 }
 
 .rest-progress-inner {
     height: 100%;
     width: 100%;
     background: #4caf50;
+}
+
+.rest-progress-text {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    font-size: 0.6rem;
+    line-height: 0.5rem;
+    color: #000;
 }
 
 .prev-attempts {


### PR DESCRIPTION
## Summary
- replace text-based delete buttons with trash can icons
- move rest progress bar onto its own line and display remaining time
- play a short beep and send a notification when rest ends
- request notification permission on app start

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864fa981a688327b3b1340efdaf72de