### PR TITLE
Add service worker auto-update support

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -13,6 +13,20 @@ self.addEventListener('install', event => {
   );
 });
 
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(resp => resp || fetch(event.request))


### PR DESCRIPTION
## Summary
- add service worker activation handling and skipWaiting message
- periodically check for updated service worker and reload when new version is installed

## Testing
- `node --check service-worker.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68652e027ff8832784f9e5eed146bbe8