### PR TITLE
Add workout timer and footer version

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
     <button id="save-template" title="Save Template">⭐</button>
   </div>
 
+  <section id="workout-timer-section" class="hidden">
+    <button id="start-workout">Start Workout</button>
+    <button id="pause-workout" class="hidden">Pause</button>
+    <button id="resume-workout" class="hidden">Resume</button>
+    <button id="end-workout" class="hidden">End Workout</button>
+    <span id="workout-time">00:00:00</span>
+  </section>
+
   <section id="start-section">
     <h2>Select Workout</h2>
     <button id="start-blank">Start Blank Workout</button>
@@ -23,6 +31,7 @@
       <button id="export-data">Export Data</button>
       <button id="import-data-button">Import Data</button>
       <input type="file" id="import-data" accept="application/json" class="hidden">
+      <button id="show-instructions">File Format</button>
     </div>
   </section>
 
@@ -49,6 +58,20 @@
     <div id="history-list"></div>
   </section>
 
+  <section id="instructions-section" class="hidden">
+    <h2>Import/Export File Format</h2>
+    <p>The exported file is JSON structured as:</p>
+    <pre>{
+  "currentWorkout": { ... },
+  "workoutHistory": [ ... ],
+  "workoutTemplates": [ ... ],
+  "exerciseHistory": { ... }
+}</pre>
+    <p>Create a file with the same structure to import your data.</p>
+    <button id="instructions-back">Back</button>
+  </section>
+
   <script src="script.js"></script>
+  <footer id="app-version"></footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -130,3 +130,18 @@ ul {
     justify-content: center;
 }
 
+#workout-timer-section {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+footer {
+    text-align: center;
+    margin-top: 1rem;
+    font-size: 0.8rem;
+    color: #666;
+}
+


### PR DESCRIPTION
## Summary
- add workout timer section with start/pause/resume/end controls
- show file format instructions in a new section
- display unique version in footer
- show done status and day part in history
- style timer and footer
- remove mailto export

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686535cc73a88327b4d366d690d5af8b