### PR TITLE
Implement template tracking and timed sets

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
     <span id="timer-display">60</span>
   </section>
 
+  <section id="set-timer-section" class="hidden">
+    <span id="set-timer-display">0</span>
+  </section>
+
   <section id="workout-section" class="hidden">
     <h2>Exercises</h2>
     <textarea id="workout-comment" placeholder="Workout comment"></textarea>

--- a/style.css
+++ b/style.css
@@ -52,6 +52,12 @@ textarea {
     margin-left: 1rem;
 }
 
+#set-timer-section {
+    text-align: center;
+    font-size: 2rem;
+    margin-top: 0.5rem;
+}
+
 .exercise {
     background: #fff;
     padding: 0.5rem;
@@ -78,6 +84,10 @@ textarea {
 
 .set-item input[type="number"] {
     width: 4rem;
+    margin-right: 0.25rem;
+}
+
+.start-timer {
     margin-right: 0.25rem;
 }
 


### PR DESCRIPTION
## Summary
- track template name when saving a workout to history
- allow exercises to specify a time per set
- add countdown timer button for timed sets
- export data files with a timestamped filename

## Testing
- `node -c script.js` *(fails: bad option)*

------
https://chatgpt.com/codex/tasks/task_e_6865ad05e0a48327a7d643506c346e0c