### PR TITLE
Enhance exercise charts and sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,12 @@
     </div>
     <div id="exercise-overview">
       <h3>Exercises</h3>
+      <label>Sort by:
+        <select id="exercise-sort">
+          <option value="recent">Most Recent</option>
+          <option value="alpha" selected>Alphabetical</option>
+        </select>
+      </label>
       <div id="exercise-list-home"></div>
     </div>
   </section>
@@ -72,6 +78,7 @@
     <button id="exercise-chart-back">Back</button>
     <h2 id="exercise-chart-title"></h2>
     <canvas id="exercise-chart" width="400" height="300"></canvas>
+    <div id="exercise-chart-legend"></div>
   </section>
 
   <section id="instructions-section" class="hidden">

--- a/style.css
+++ b/style.css
@@ -195,3 +195,27 @@ footer {
     border: 1px solid #ccc;
 }
 
+#exercise-chart-legend {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 0.25rem;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    font-size: 0.9rem;
+}
+
+.legend-color {
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.25rem;
+}
+
+#exercise-overview label {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+


### PR DESCRIPTION
## Summary
- add exercise sort dropdown
- implement sorting by most recent or alphabetically
- draw legends for exercise charts
- chart sets and reps on left/right axes
- bump version to 1.8

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6866a2b1f4a88327b75147c53a8546c4