### PR TITLE
Add set status slider and progress timer

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,6 +152,11 @@ ul {
     margin-top: 0.25rem;
 }
 
+.status {
+    width: 5rem;
+    margin-right: 0.25rem;
+}
+
 #data-buttons {
     margin-top: 1rem;
     display: flex;


### PR DESCRIPTION
## Summary
- add a slider for set status with three states
- show previous attempts only when values exist
- convert rest timer into per-set progress bar
- notify when set timer completes
- store set completion using `status` instead of boolean
- bump app version

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_686a487202008327a3c74f4255be2e4f