### PR TITLE
Improve status slider feedback

### DIFF
--- a/style.css
+++ b/style.css
@@ -156,6 +156,10 @@ ul {
     width: 5rem;
     margin-right: 0.25rem;
 }
+.status-text {
+    margin-right: 0.25rem;
+    font-size: 0.8rem;
+}
 
 #data-buttons {
     margin-top: 1rem;


### PR DESCRIPTION
## Summary
- display text label for each set status
- update rest timer logic to trigger on failed sets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a4ef2a0e88327b0bba6e1d8c021d8