### PR TITLE
Shrink set inputs & bump version

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '1.11';
+const APP_VERSION = '1.12';
 const STATUS_LABELS = ['Not done', 'Failed', 'Completed'];
 const exerciseList = document.getElementById('exercise-list');
 const addExerciseForm = document.getElementById('add-exercise-form');

--- a/style.css
+++ b/style.css
@@ -83,7 +83,7 @@ textarea {
 }
 
 .set-item input[type="number"] {
-    width: 3rem;
+    width: 2.5rem;
     margin-right: 0.25rem;
 }
 
@@ -153,7 +153,7 @@ ul {
 }
 
 .status {
-    width: 5rem;
+    width: 3.5rem;
     margin-right: 0.25rem;
 }
 .status-text {


### PR DESCRIPTION
## Summary
- reduce width of number and slider inputs so a set fits on one row
- bump app version to 1.12

## Testing
- `grep -n 1.12 -R`

------
https://chatgpt.com/codex/tasks/task_e_686a6d4c204083278886437233e88343