### PR TITLE
Add navigation bar and profile page

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,15 @@
     <div id="exercise-chart-legend"></div>
   </section>
 
+  <section id="profile-section" class="hidden">
+    <h2>Profile</h2>
+    <label>Name: <input type="text" id="profile-name"></label>
+    <label>Notes:
+      <textarea id="profile-notes" rows="4"></textarea>
+    </label>
+    <button id="save-profile">Save</button>
+  </section>
+
   <section id="instructions-section" class="hidden">
     <h2>Import/Export File Format</h2>
     <p>The exported file is JSON structured as:</p>
@@ -95,6 +104,13 @@
   </section>
 
   <script src="script.js"></script>
+  <nav id="bottom-nav">
+    <button id="nav-home">Home</button>
+    <button id="nav-exercises">Exercises</button>
+    <button id="nav-workout">Workout</button>
+    <button id="nav-history">History</button>
+    <button id="nav-profile">Profile</button>
+  </nav>
   <footer id="app-version"></footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const APP_VERSION = '1.12';
+const APP_VERSION = '1.13';
 const STATUS_LABELS = ['Not done', 'Failed', 'Completed'];
 const exerciseList = document.getElementById('exercise-list');
 const addExerciseForm = document.getElementById('add-exercise-form');
@@ -42,6 +42,15 @@ const exerciseChartBack = document.getElementById('exercise-chart-back');
 const exerciseChartLegend = document.getElementById('exercise-chart-legend');
 const exerciseSortSelect = document.getElementById('exercise-sort');
 const resumeHomeBtn = document.getElementById('resume-workout-home');
+const navHome = document.getElementById('nav-home');
+const navExercises = document.getElementById('nav-exercises');
+const navWorkout = document.getElementById('nav-workout');
+const navHistory = document.getElementById('nav-history');
+const navProfile = document.getElementById('nav-profile');
+const profileSection = document.getElementById('profile-section');
+const profileName = document.getElementById('profile-name');
+const profileNotes = document.getElementById('profile-notes');
+const saveProfileBtn = document.getElementById('save-profile');
 
 let exerciseSortOrder = 'alpha';
 
@@ -159,7 +168,7 @@ async function confirmEndCurrentWorkout() {
       return true;
     } else {
       startSection.classList.add('hidden');
-      showWorkoutUI(true);
+      showWorkoutPage();
       return false;
     }
   }
@@ -450,6 +459,59 @@ function showWorkoutUI(show) {
     if (show) sec.classList.remove('hidden');
     else sec.classList.add('hidden');
   });
+}
+
+function hideMainSections() {
+  [startSection, addExerciseSection, workoutSection, historySection, profileSection, instructionsSection, exerciseChartSection].forEach(sec => {
+    if (sec) sec.classList.add('hidden');
+  });
+  if (topButtons) topButtons.classList.add('hidden');
+  if (restSection) restSection.classList.add('hidden');
+  if (workoutTimerSection) workoutTimerSection.classList.add('hidden');
+}
+
+function showHome() {
+  hideMainSections();
+  if (startSection) startSection.classList.remove('hidden');
+  updateResumeButton();
+}
+
+function showExercisesPage() {
+  hideMainSections();
+  if (addExerciseSection) addExerciseSection.classList.remove('hidden');
+}
+
+function showWorkoutPage() {
+  hideMainSections();
+  if (workoutSection) workoutSection.classList.remove('hidden');
+  if (addExerciseSection) addExerciseSection.classList.remove('hidden');
+  if (restSection) restSection.classList.remove('hidden');
+  if (topButtons) topButtons.classList.remove('hidden');
+  if (workout.exercises && workout.exercises.length > 0) {
+    if (workoutTimerSection) workoutTimerSection.classList.remove('hidden');
+  }
+}
+
+function showHistoryPage() {
+  hideMainSections();
+  if (historySection) historySection.classList.remove('hidden');
+}
+
+function showProfilePage() {
+  hideMainSections();
+  if (profileSection) profileSection.classList.remove('hidden');
+  loadProfile();
+}
+
+function loadProfile() {
+  const data = JSON.parse(localStorage.getItem('profile') || '{}');
+  if (profileName) profileName.value = data.name || '';
+  if (profileNotes) profileNotes.value = data.notes || '';
+}
+
+function saveProfile() {
+  const data = { name: profileName.value, notes: profileNotes.value };
+  localStorage.setItem('profile', JSON.stringify(data));
 }
 
 let currentProgress = null;
@@ -1008,15 +1070,14 @@ startBlankBtn.addEventListener('click', async () => {
   renderCurrentTemplate();
   saveWorkout();
   startSection.classList.add('hidden');
-  showWorkoutUI(true);
+  showWorkoutPage();
   endWorkoutTimer();
   renderWorkout();
   await renderHistory();
 });
 
 homeBtn.addEventListener('click', () => {
-  showWorkoutUI(false);
-  startSection.classList.remove('hidden');
+  showHome();
   clearInterval(restTimer);
   updateResumeButton();
 });
@@ -1024,7 +1085,7 @@ homeBtn.addEventListener('click', () => {
 if (resumeHomeBtn) {
   resumeHomeBtn.addEventListener('click', () => {
     startSection.classList.add('hidden');
-    showWorkoutUI(true);
+    showWorkoutPage();
   });
 }
 
@@ -1043,6 +1104,19 @@ startWorkoutBtn.addEventListener('click', startWorkoutTimer);
 pauseWorkoutBtn.addEventListener('click', pauseWorkoutTimer);
 resumeWorkoutBtn.addEventListener('click', resumeWorkoutTimer);
 endWorkoutBtn.addEventListener('click', finishWorkout);
+
+if (navHome) navHome.addEventListener('click', showHome);
+if (navExercises) navExercises.addEventListener('click', showExercisesPage);
+if (navWorkout) navWorkout.addEventListener('click', showWorkoutPage);
+if (navHistory) navHistory.addEventListener('click', showHistoryPage);
+if (navProfile) navProfile.addEventListener('click', showProfilePage);
+
+if (saveProfileBtn) {
+  saveProfileBtn.addEventListener('click', () => {
+    saveProfile();
+    alert('Profile saved');
+  });
+}
 
 historyList.addEventListener('click', async e => {
   if (e.target.classList.contains('del-history')) {
@@ -1118,7 +1192,7 @@ templateList.addEventListener('click', async e => {
       renderCurrentTemplate();
       saveWorkout();
       startSection.classList.add('hidden');
-      showWorkoutUI(true);
+      showWorkoutPage();
       endWorkoutTimer();
       renderWorkout();
       await renderHistory();
@@ -1128,6 +1202,7 @@ templateList.addEventListener('click', async e => {
 
 function init() {
   loadWorkout();
+  loadProfile();
   renderExerciseOptions();
   renderExerciseListHome();
   renderHistory();
@@ -1137,10 +1212,9 @@ function init() {
   updateResumeButton();
   if (workout.exercises && workout.exercises.length > 0) {
     startSection.classList.add('hidden');
-    showWorkoutUI(true);
+    showWorkoutPage();
   } else {
-    showWorkoutUI(false);
-    startSection.classList.remove('hidden');
+    showHome();
   }
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('service-worker.js').then(reg => {

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@ body {
         Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     margin: 0;
     padding: 1rem;
+    padding-bottom: 4rem;
     background-color: #f4f4f4;
 }
 
@@ -226,5 +227,25 @@ footer {
 #exercise-overview label {
     display: block;
     margin-bottom: 0.25rem;
+}
+
+#bottom-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    background: #fff;
+    border-top: 1px solid #ccc;
+    padding: 0.5rem 0;
+    box-sizing: border-box;
+}
+
+#bottom-nav button {
+    flex: 1;
+    background: none;
+    border: none;
+    font-size: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- add profile section and bottom navigation bar
- implement JS navigation handlers and profile storage
- bump app version

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes stylelint style.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_686a6e7d535883278a7d6ff0a748a6a3